### PR TITLE
Add ruff linting configuration

### DIFF
--- a/crew/pyproject.toml
+++ b/crew/pyproject.toml
@@ -16,3 +16,29 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+extend-select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D",   # pydocstyle
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific
+]
+extend-ignore = [
+    "D100",  # Missing docstring in public module
+    "D104",  # Missing docstring in public package
+    "D107",  # Missing docstring in __init__
+]
+
+[tool.ruff.per-file-ignores]
+"tests/**/*.py" = ["D"]  # Disable docstring checks in tests
+
+[tool.ruff.pydocstyle]
+convention = "google"


### PR DESCRIPTION
Adds ruff linting configuration to pyproject.toml with:

- Line length of 100
- Python 3.12 target
- Standard rule sets (pycodestyle, pyflakes, isort, etc)
- Google docstring convention
- Reasonable exclusions for missing docstrings
- Disable docstring checks in tests

This will help maintain consistent code quality as the codebase grows.

Closes #2