### PR TITLE
Add pytest test file for GitHub tools

### DIFF
--- a/crew/tests/test_tools.py
+++ b/crew/tests/test_tools.py
@@ -1,6 +1,5 @@
-from unittest.mock import patch, Mock
 import pytest
-
+from unittest.mock import Mock, patch
 from src.tools.github_tool import (
     list_open_issues,
     list_open_prs,
@@ -19,71 +18,68 @@ from src.tools.github_tool import (
 @pytest.fixture
 def mock_github():
     with patch('src.tools.github_tool.Github') as mock:
-        mock_repo = Mock()
-        mock.return_value.get_repo.return_value = mock_repo
-        yield mock, mock_repo
+        yield mock
 
-def test_list_open_issues(mock_github):
-    _, mock_repo = mock_github
+@pytest.fixture
+def mock_repo(mock_github):
+    repo = Mock()
+    mock_github.return_value.get_repo.return_value = repo
+    return repo
+
+def test_list_open_issues(mock_repo):
     mock_issue = Mock()
     mock_issue.number = 1
     mock_issue.title = "Test Issue"
-    mock_issue.body = "Issue body"
+    mock_issue.body = "Test Body"
     mock_repo.get_issues.return_value = [mock_issue]
 
-    issues = list_open_issues("owner/repo")
-    assert len(issues) == 1
-    assert "#1: Test Issue" in issues
+    result = list_open_issues("owner/repo")
+    assert "#1: Test Issue" in result
+    mock_repo.get_issues.assert_called_once_with(state='open')
 
-def test_create_issue(mock_github):
-    _, mock_repo = mock_github
-    mock_issue = Mock()
-    mock_issue.number = 2
-    mock_repo.create_issue.return_value = mock_issue
-
-    result = create_issue(
-        "owner/repo",
-        "New Issue",
-        "Issue description",
-        labels=["bug"],
-    )
+def test_create_issue(mock_repo):
+    mock_repo.create_issue.return_value.number = 2
+    
+    result = create_issue("owner/repo", "New Issue", "Issue Body")
     assert "Created issue #2" in result
     mock_repo.create_issue.assert_called_once_with(
         title="New Issue",
-        body="Issue description",
-        labels=["bug"],
+        body="Issue Body"
     )
 
-def test_create_branch(mock_github):
-    _, mock_repo = mock_github
-    mock_ref = Mock()
-    mock_ref.object.sha = "main-sha"
-    mock_repo.get_git_ref.return_value = mock_ref
+def test_add_labels(mock_repo):
+    mock_issue = Mock()
+    mock_repo.get_issue.return_value = mock_issue
+    
+    result = add_labels("owner/repo", 1, ["bug", "good-first-issue"])
+    assert "Added labels" in result
+    mock_repo.get_issue.assert_called_once_with(1)
+    mock_issue.add_to_labels.assert_called_once_with("bug", "good-first-issue")
 
-    result = create_branch("owner/repo", "fix/test-branch")
-    assert "Created branch fix/test-branch" in result
+def test_create_branch(mock_repo):
+    mock_repo.get_git_ref.return_value.object.sha = "main-sha"
+    
+    result = create_branch("owner/repo", "feature/test")
+    assert "Created branch feature/test" in result
     mock_repo.create_git_ref.assert_called_once_with(
-        ref="refs/heads/fix/test-branch",
-        sha="main-sha",
+        ref="refs/heads/feature/test",
+        sha="main-sha"
     )
 
-def test_create_pull_request(mock_github):
-    _, mock_repo = mock_github
-    mock_pr = Mock()
-    mock_pr.number = 3
-    mock_repo.create_pull.return_value = mock_pr
-
+def test_create_pull_request(mock_repo):
+    mock_repo.create_pull.return_value.number = 3
+    
     result = create_pull_request(
         "owner/repo",
-        "fix/test-branch",
+        "feature/test",
         "main",
         "Test PR",
-        "PR description\n\nFixes #1",
+        "PR Body"
     )
     assert "Created PR #3" in result
     mock_repo.create_pull.assert_called_once_with(
         title="Test PR",
-        body="PR description\n\nFixes #1",
-        head="fix/test-branch",
-        base="main",
+        body="PR Body",
+        head="feature/test",
+        base="main"
     )


### PR DESCRIPTION
This PR adds a new test file `crew/tests/test_tools.py` with unit tests for the GitHub tools module. The tests cover:

- Listing open issues
- Creating new issues
- Adding labels
- Creating branches
- Creating pull requests

Tests use pytest fixtures and mocking to isolate the GitHub API calls.

Future improvements could add more test cases and coverage for remaining tool functions.